### PR TITLE
Fix kea example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Examples:
 * [structure of the word <q lang="de" style="quotes: '„' '“'">satanarchäolügenialkohöllisch</q>](https://lucaswerkmeister.github.io/wikidata-lexeme-graph-builder/?subjects=L129&predicates=P5191)
 * [words derived from Proto-Indo-European <q lang="mis-x-Q37178">*uber</q>](https://lucaswerkmeister.github.io/wikidata-lexeme-graph-builder/?subjects=L2087&predicates=P5191)
 * [structure of the <q>Aberystwyth</q> toponym](https://lucaswerkmeister.github.io/wikidata-lexeme-graph-builder/?subjects=L4730&predicates=P5191%2CP5238)
-* [translations and synonyms of the Cape Verdean Creole <q lang="kea">oi</q>](https://lucaswerkmeister.github.io/wikidata-lexeme-graph-builder/?subjects=L501335&predicates=P5972%2CP5973)
+* [translations and synonyms of the Cape Verdean Creole <q lang="kea">odju</q>](https://lucaswerkmeister.github.io/wikidata-lexeme-graph-builder/?subjects=L501298&predicates=P5972%2CP5973)
 
 ## License
 


### PR DESCRIPTION
The "oi" lexeme was actually a dialectal variant of "odju" (L501298), so it was added as a form there.
The existing lexeme (L501335) was reused into a separate term (for "dog").